### PR TITLE
feat(game): add tap feedback with click sfx and multi-tap lock

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,10 +1,13 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { PALETTE } from "./colors";
-import { playCorrect, playWrong } from "./sounds";
+import { playClick, playCorrect, playWrong } from "./sounds";
 
 export default function App() {
   // 使う色セット（初期は3色）
   const [currentColors, setCurrentColors] = useState(PALETTE.slice(0, 3));
+
+  // ダブルタップ防止用のロック
+  const lockRef = useRef(false);
 
   // 今タップしてほしい「正解の色」
   const [target, setTarget] = useState(PALETTE[0]);
@@ -60,6 +63,13 @@ export default function App() {
 
   // 色タップ時の判定
   const onTap = (c) => {
+    // ダブルタップ防止：ロック中なら無視
+    if (lockRef.current) return;
+    lockRef.current = true;
+
+    // タップ時は必ずクリック音を鳴らす
+    playClick();
+
     if (c.name === target.name) {
       // 正解：緑フラッシュ → メッセージ更新 → ストリーク+1 → 正解音
       setFlash("ok");
@@ -72,6 +82,7 @@ export default function App() {
         setFlash(null);
         setMessage("Tap this color");
         nextTarget();
+        lockRef.current = false;
       }, 600);
     } else {
       // 不正解：赤フラッシュ → メッセージ更新 → ストリークリセット → エラー音
@@ -84,6 +95,7 @@ export default function App() {
       setTimeout(() => {
         setFlash(null);
         setMessage("Tap this color");
+        lockRef.current = false;
       }, 500);
     }
   };


### PR DESCRIPTION
## Summary
- Play click sfx on every color tap
- Add ref lock to prevent double-tap processing during feedback animation
- Unlock after feedback timeout (600ms for correct, 500ms for wrong)

## Note
Sound files are currently empty (0 bytes). Actual audio files will be added in #13.

## Test plan
- [x] Tap a color tile - click sound should play (once #13 adds files)
- [x] Rapid taps are ignored during feedback animation
- [x] Lock releases after feedback completes

close #5